### PR TITLE
Fix PDF preview in Firefox/Waterfox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ screenshots/
 explore-site.mjs
 public/js/app.js
 public/js/app.js.map
+
+# Local Netlify folder
+.netlify


### PR DESCRIPTION
## Summary
- Switched PDF preview iframe from blob URL (`URL.createObjectURL`) to data URL (`jsPDF.output('dataurlstring')`)
- Firefox-based browsers (Firefox, Waterfox) treat blob URLs with PDF MIME type as downloads instead of inline content, leaving the preview empty
- Data URLs are rendered inline consistently across all browsers

Fixes #1

<!-- netlify-preview -->
---
**Deploy Preview:** https://69988b61498b2f6cc2e933cf--easypdf-lite.netlify.app