### PR TITLE
Prevent invoice items sum row wrapping

### DIFF
--- a/public/js/pdf-generator.ts
+++ b/public/js/pdf-generator.ts
@@ -431,7 +431,7 @@ function drawItemsTable(
   // Sum row: last column shows "SUM: {formattedTotal}", rest are empty
   const sumRowIndex = body.length;
   const sumRow: string[] = columns.map((_col, idx) => {
-    if (idx === columns.length - 1) {
+    if (idx === 0) {
       return `${t.invoiceItemsTable.sum}: ${formatNumber(data.total)}`;
     }
     return '';
@@ -480,9 +480,14 @@ function drawItemsTable(
 
       // Style the sum row (always last)
       if (rowIdx === sumRowIndex) {
-        hookData.cell.styles.fontStyle = 'bold';
-        hookData.cell.styles.fillColor = TABLE_HEADER_BG;
-        hookData.cell.styles.halign = 'right';
+        if (hookData.column.index === 0) {
+          hookData.cell.colSpan = columns.length;
+          hookData.cell.styles.fontStyle = 'bold';
+          hookData.cell.styles.fillColor = TABLE_HEADER_BG;
+          hookData.cell.styles.halign = 'right';
+        } else {
+          hookData.cell.text = [];
+        }
       }
 
       // Style note sub-rows: merge across all columns, italic, lighter bg


### PR DESCRIPTION
## What changed

The invoice items table adds a final sum row like:

~~~
Spolu: 1 100.00
~~~

When the last column gets narrow (many visible columns), jspdf-autotable may wrap this string and split the number across lines.

This change makes the sum row render in the first column and merges the sum row across all columns to avoid wrapping in a narrow cell.

## Implementation

- Move sum row content to the first column
- Set colSpan on the first sum-row cell and hide the remaining cells

## Testing

- bun test tests/
- bunx playwright test

<!-- deploy-preview -->
---
**Deploy Preview:** https://69ecf7d0568a3aa5f0229395--easypdf-lite.netlify.app/

**Prefilled test links:**
- [Mixed VAT + long total row](https://69ecf7d0568a3aa5f0229395--easypdf-lite.netlify.app/?data=N4IgjCBcIGoIIBUQBoQFYoG1QDYogGUBpAVRRAHYoAXAJwFcBTVAL3wGcBrekAX2Vz4ACgAsAhu0bkqkOk1b4ADuMl8AuqjH5GAO3IAjfAE0TRgLQBZC2YAiN8gGN8AURIAlcgBN8nxgDMxegAbanI-KFAAD3wASR0ANwB7AEsHKVQAT2E3ZxgY5wB1MwAZAHkAOQBxMwAGGoh%2BEABzfAAmGtacWoAWM1aMVBE2jq6a3v7yZNiElLTyACsaBmYQTgiQVvx4BAACcsTyOBcJDKEbADEdoVpGeOTGAHcdgkYgoMZacgAhfDA6neckTEAFtFO9nnRGIxqAAdHRwYHsagfTwg8gAYXw5WKYFaAGZumgcBQABwATi%2B9XI9lky1Qzg4r3etAAAowgaD3gA6ZFI8jnLHFMlgOBfcpwMZgChgHDdPF1ciVJbyEAACXwovF2NaR1QMWVK1C0HIPEgASCkkaQXWm2g2z2B1QR2g11u9yeX3oGQ%2BO2K1G8qB%2B0HaNR26PoSMSwJ9cHiuiYcK%2BHyCyT0qEx0BszjJJIoODQctaEFQNLkKwZ0H0Xo%2BbI5YMYPMYfNQRpAJqg5stqGBWFANQNqDx0wcQXovnYO0SOn0iTEtE8qaayB27HoikUiVo1GXYh0nh2DijYOSu7SOxuG63i655G6A5AJPWXFNhDEYgIZmc5SQqGUEik0BuLojxiNajQAFL3s6IBwDoOj0KBzxvgQOxgmI1B%2BJuwIrvQ%2BjsA4tDJIo1DJFOOwPMk1AiDsYg7L4Kb6B86GvBkOxBFOTR0U2BFESRZGYbQ56JE8Dy0GI66LuQRD3sU%2BDkBYHagZIqDlFAYCoKU95CPg3pzuQACK94eJAuJkmSXJmagBD3kgkD4qgZC0iqMBqa0ZkWWSqAFPeAAaUBuSSHkUBQqBGPeABaaloDmFm5hQdQJQlYD8H295DsaqB3maSkrI%2BkCgM%2B%2BAEM4bgwGYBRENZv4qABIA2K8yRxrQWQQVBsScow0Y6NQ6GkTo5Gbpw7AiIkiioWIDicGITTpCA0lOSsskZSACnZRaKyqZAeIaVpPhiFkqCGQtqDGa0FBoFyaBWTZUAkg594uZAJKdJdXm%2BVAOA4FyuKhRFt1kq0XI4K0KUgP2x0gOlbaZYp62oHlBXcC4PlCLUVLVf%2B%2BDouxkiJPQoStRD0GlPjZiJH4Zj4aNjDnowyTAlWtCSF1oSoPNZaoEt0MrbDykgJt6kgJpEPadAlGdQZRlQN0gXnddEO2TU90Q49MtcnLIDeRDfmQErIBhRDkWQGr528BoIB6HZBY1FyeJoMFqAHBDij4F8u6cDsCBiTo7B%2BB85AAI73p8wYjLUaC1GS5Ctq6dyPDsfjJJE1D0DcOwzToTHIvu%2BiseiMQ3qgpocyA8T3g8Bq8EAA) - Long item names, item notes, custom columns, and a wide sum row.
- [Stripe template + pay online](https://69ecf7d0568a3aa5f0229395--easypdf-lite.netlify.app/?data=N4IgjCBcIGoIIBUQBoQEMogKYDsUgCNMBZU4gAgBFlyBNe2-AY0wFUBlS-AE0wGcALgCcAlgAcs%2BAGZRQAD0wBJHADcA9iKaTUAT0zsEAJUUAFAKIBaACwAmWyAC%2BqAOaYbABhsA2C%2B6sWbAFZ8AAs3Tx8-AODUESVVDS18ACsoYQBXLFQAa1kQG0x4BHIAOTV8OEwzND4dE0oAMXITISwVESwAd3J2LAAbPqwhfAAhTDB3d3IzOTQAWzFBnuEsLAEAHRw4OcEh7nn8AGFMEoAZMBsAZitArwB2AA4AThH3CFQuSAyskDN%2BfsGQgAAlhZgtBgA6ARYQT4BonU5PMBwEYlOB%2BMB3MBeKyXSb4ADiaSEmVQAAlMCi0WcbJVUIpiaSQAJMPh0lApGg%2BnwsE4QH08gVoAg0HJyIouKhKtAykIBCFOiIcNxyA0lWgcFpyAgsAdUGNoIFJuRiGghNk1stWmtNuwNaqhBqmCI%2BEw1DRDnSQMdoBwLGZFCULBcLNdbo8nvhPt9UH9oGgxCCwYssFCYSzUCzoIY1OloeQBGpyHATOQAI6ZTIQtmM3moOZQADaoHctdQl1ZqCsHK5PNQACk2yBpSBKDCRM4cORars5uQ0OluCIMyAANJD06dkDEHvcn4lKAXVAAeSHJkwIVzw1QAEUh4ZDw9Aqh2EOkJB3KhWEOYFAbP-PxAAB1IcAA0oEAxgvhJH4AC0-wApwWyHDtoHwbtIE5PcByHEd6iaTo1HNKQ%2BjUbpBDQAgRD6EQAC80AEEQ1DwVB12gplNzQ1Ad0w3t9ygB4TzPC8r3wO92J%2BB9IBsCYXzfCCvx-Q8vAeQCQIk1BwI-VAoJjEB4MgbFVIcABdVA8EgS4nkmVByg0kAxEwQ4zV4VAyyHYZoA8bxfECXxI0zTAWjaDpuikEQ5AEdJWnIZxcCGBisBVAgdHIQ5FGrVB2XslQh06Ic%2BAvAQBDEPhIAAenKpgQiwJhslzAQIUEUQJAhN05iq8qxDQHQqr4AB9aFBH6sRWnaLpHCAA) - Stripe layout, USD formatting, pay-online URL, and buyer notes.
- [German locale + CHF formatting](https://69ecf7d0568a3aa5f0229395--easypdf-lite.netlify.app/?data=N4IgjCBcILIOoGUAqIA0ICGUQBMCmaIARtgCKkB0MMFAmvbYQMbYDCAEgGKE7b4BmGAK4AbAC6F%2BUUAA9sAJTxMAFgDshqgOaEAnmQCiAWg6dDAJgAMZgGyGLAFhABfdNuiWbd%2B%2BYCshZdgetg6%2BhACW2ACSqgBuAPZhTAToAFZQYgBOQnjoANbSIGbYAKqRpIQAgtgwQgDOYngZAAQA4gC2ROyEAELY3RhqynH89RkYtbV4TWAAOqoAHBYWYE0AWkIZiQHorGzsRmBmAMwU9j7WFADs8wCchOWQmdno%2BtgZSmoamgACeDIYbQADiI8BQGvVCNxoBwbkcmktLtYmpYwCtrMd5k0fGYbj4mpdCC10lkciAutBit0EHAOKt2IsquhIsTniAJNBCEIoIIRJMXCARAUihSypVsBURIC8KomgBpDT4JoVInoXrQaI4OqZMJ4UbjSZNG5zI5LCxNbqNVSEXbQ-aGG7zS4Uaw%2BewUI5mCDoB5PUmvaC5BV4X7-IEgsG6iTodkgTncjC8vD8tpQADaoAsLNJR2whEckB5k3QACks%2BgqtALWMxF9aoCMLk8FGQLKyyAADK59AweOJ9AAOSgZgoPnQAHk2wAFbBIDDadAARTb8ig1nsFnQCDbKEg8woYHQxTbADUoGBrEt0HA2wANM8453oRiPEnoVZny4P6wuDNtnMc9B80LUlSxfVkKw7MIAC9pSgwhWzA0lOwA2BeyLEBB0gA8QAnRD0GnaAEDEfJF2Xe9LxALc8JAHc92wo9qNPLDLA3EBr2ou9IBuJ0zCfNt32Y7iKDMJwAF10CtSATRsCh5nQOI20BPoMFUXImiQMZVFqfhGkIABHNsMkCKxgh8Ow7mjbBJ3eGIdQAdyafgwhkGt3iaTRpUaDAGhwJoiB0JpWEiCg42omI2zsrMnCAA) - Localized labels, date format, currency formatting, and custom tax label.
- [Slovak locale smoke](https://69ecf7d0568a3aa5f0229395--easypdf-lite.netlify.app/?data=N4IgjCBcICIAoAkQBoQEMogM4GsUgCNMYYA6AWXNIE1br8BjTAUQFUAlfAE0y4FMAZmgCuAGwAu%2BAVFAAPTADE0OccIBOGVAE9MAZQDSAWgBMABmMA2Q6dMQAvqgDmmM5esAWEwFZ8ACxfmVqaexj6oAJaKyqoa%2BABWUOJqwnyoeJCgxpgAkgDCAATwSKgAgsQA9lxoAG5o4nyi%2BQAqfFji%2BVikaqTlpPgAQpgIojUAdmj5YAA6owAcYGD5tvn9GuLhWCO1%2BLl6%2Bq4WYMYAzO5eFvgwicmpIMy8lTV1DQACfLJoALYADqJ8pPU2vgFHtjosjjYljZTJMAJyzADs%2BXclmO%2BQRXncEFQAHFrilUEhoLpWP0SgZ%2BgANfDZfG3STQfDCKBCURYPgOECiGQgLLQPKFRD4MrQADyXAIfDWDUKfE%2B5XyaFInQGmAAcl9Wus%2BPkvDNgjDlvpylhwgw%2BDs9gd4QiLJjLnTUPdoJVJdLRG8Pj8-gCtfgGSAmSy0GyOahPlAANqgUyOkDHTD4dzB0OoABScZFIGNowAXmJxGgGOEdTh8kIVOoi6M5cJ8gB3cpqHACUTlevM1D6OMAGUTqHIKfZqDVUHcqFFcbgmF8lXwAEU45xIBDULo400oGZUKw4wA1MezUyoADqcepkFhFlQ9EgSQJIAAWlAvLaHDG4wnGahk5BWcOQAzO8blKTB2HKBhxnyUQzT4UZiwmZg0CwLQ4BgBR8h7cJ6nwbtgIfPtvxAQc-xDADRxXCcp0wHAsAXJcx1hWE1w3LdjxAXd8NuA9IHcJjT3PKAmNIWYbzjZ9IC8eERLsABdVBRigBYEXcETUHKONvkwfo0FGHBymqLR8m%2BNQ%2BGqOdUAARzjNQAjcUwvGsWF-T0NtajLNsGBDHUTLMkt63LcJZBif4gy41Bqjjes6TsIA) - Slovak labels, EUR formatting, and DPH tax wording.
- [Shared link without QR payload](https://69ecf7d0568a3aa5f0229395--easypdf-lite.netlify.app/?data=N4IgjCBcIGoIIBUQBoQEMogKYDsUgCNMARYgegFkKyBNOm-AY0wHEAhABXwBNNusAZmgCuAGwAu%2BAVFAAPTAEkcANwD2AS0ZZ8AT0wA5APIBaAIoAlYwoDKhgDKIFh-SAC%2BqAOaYATAAZvAGzGvgAsxt4ArPgAFj7%2BQaHhUajqiioaWvgAVlDiAE7CWKgA1jIg3pjwCAAE%2Bqr4cJgAomgAzjocxABi1Rx5WMrqWADu1dZYoqJYefhsmGC%2BvtVNsmgAtgAOU2P5WFjiADo4cGut4tPc6-gAwgZ2YN4AzCERAQDsABwAnGy%2BEKjEXIFIogJqYVoTKZ5AACWFWmymADpzmd8F07l8wHA2Po4KEwG8wAEQo9FvgWEDCqgABKYbG4-R2byNVAKSkgyTQfDCKBCUQQ9wgURlCrQKq1eqoRrQPoDIajNjCHTTap2cS8VBzaB%2BJbXYRnVRrFVwZS4QpHNjTUTqPCoW7QYhNL4fN4BCIk7z-ECAyD5KmgzAEJXTWHwrZYZFYVGoTkgbm8tD8rCCtZQADaoF87NQj0w%2BBCCaTqAAUtmQNKQBZjAJ%2Blhqq1omh%2Btxqja1Jo6601qpinWUZJUABpMt2POoCiFiGoFyQMCoQxlrjQfv4Uxl8xQL5fRFb1DWMtISB%2BVAAVTLME3293IAA6mWABpQMBX52oBi%2B4GoABaT%2BfO4%2BHyuAAuqgeCzn%2BzofKg9Qfv6GyYGwaA4MU1QIHkSGtAI0z4AAjmWMzavEwQRMEXz4LGCDROorTVAI6iyOIwj9K2ODnKx6iqDgiaiDo1SMJx4hoDaNE4Ko1QWNUGxoDooiqGg3CIvGsEgsoZbDOyrhAA) - No QR data, for checking that local QR state does not leak into shared invoices.
